### PR TITLE
Add jenkins_tmpdir variable to change Jenkins temporary dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The system hostname; usually `localhost` works fine. This will be used during se
 
 The Jenkins home directory which, amongst others, is being used for storing artifacts, workspaces and plugins. This variable allows you to override the default `/var/lib/jenkins` location.
 
+    jenkins_tmpdir: /var/lib/jenkins/tmp
+
+The Jenkins tmp directory where Jenkins put tmp files. This variable allows you to override the default `/tmp` location.
+
     jenkins_http_port: 8080
 
 The HTTP port for Jenkins' web interface.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ jenkins_prefer_lts: false
 jenkins_connection_delay: 5
 jenkins_connection_retries: 60
 jenkins_home: /var/lib/jenkins
+jenkins_tmpdir: ""
 jenkins_hostname: localhost
 jenkins_http_port: 8080
 jenkins_jar_location: /opt/jenkins-cli.jar
@@ -42,7 +43,7 @@ jenkins_init_changes:
   - option: "JENKINS_OPTS"
     value: "{{ jenkins_options }}"
   - option: "JAVA_OPTS"
-    value: "{{ jenkins_java_options }}"
+    value: "{% if jenkins_tmpdir | length > 0 %} -Djava.io.tmpdir={{ jenkins_tmpdir }} {% endif %}{{ jenkins_java_options }}"
   - option: "JENKINS_HOME"
     value: "{{ jenkins_home }}"
   - option: "JENKINS_PREFIX"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+
 - name: restart jenkins
   service: name=jenkins state=restarted
 

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -39,6 +39,10 @@
     mode: 0644
   with_items: "{{ jenkins_init_changes }}"
   register: jenkins_init_prefix
+  notify: reload systemd
+
+- name: "Force systemd to be reload before atempting to restart jenkins"
+  meta: flush_handlers
 
 - name: Ensure jenkins_home {{ jenkins_home }} exists.
   file:
@@ -48,6 +52,16 @@
     group: jenkins
     mode: u+rwx
     follow: true
+
+- name: Ensure jenkins_tmpdir {{ jenkins_tmpdir }} exists.
+  file:
+    path: "{{ jenkins_tmpdir }}"
+    state: directory
+    owner: jenkins
+    group: jenkins
+    mode: u+rwx
+    follow: true
+  when: jenkins_tmpdir | length > 0
 
 - name: Immediately restart Jenkins on init config changes.
   systemd:

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -68,7 +68,7 @@
     follow: true
   when: jenkins_tmpdir | length > 0
 
-- name: "Force systemd to be reload before atempting to restart jenkins"
+- name: Force systemd to be reloaded before atempting to restart jenkins
   meta: flush_handlers
 
 - name: Immediately restart Jenkins on init config changes.

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -41,9 +41,6 @@
   register: jenkins_init_prefix
   notify: reload systemd
 
-- name: "Force systemd to be reload before atempting to restart jenkins"
-  meta: flush_handlers
-
 - name: Ensure jenkins_home {{ jenkins_home }} exists.
   file:
     path: "{{ jenkins_home }}"
@@ -52,6 +49,14 @@
     group: jenkins
     mode: u+rwx
     follow: true
+
+- name: Create custom init scripts directory.
+  file:
+    path: "{{ jenkins_home }}/init.groovy.d"
+    state: directory
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
+    mode: 0775
 
 - name: Ensure jenkins_tmpdir {{ jenkins_tmpdir }} exists.
   file:
@@ -63,6 +68,9 @@
     follow: true
   when: jenkins_tmpdir | length > 0
 
+- name: "Force systemd to be reload before atempting to restart jenkins"
+  meta: flush_handlers
+
 - name: Immediately restart Jenkins on init config changes.
   systemd:
     name: jenkins
@@ -70,14 +78,6 @@
     daemon_reload: true
   when: jenkins_init_prefix.changed
   tags: ['skip_ansible_lint']
-
-- name: Create custom init scripts directory.
-  file:
-    path: "{{ jenkins_home }}/init.groovy.d"
-    state: directory
-    owner: "{{ jenkins_process_user }}"
-    group: "{{ jenkins_process_group }}"
-    mode: 0775
 
 - name: Configure proxy config for Jenkins
   template:


### PR DESCRIPTION
- enh: Add jenkins_tmpdir variable to change Jenkins temporary dir (/tmp by default)
- fix: force systemd reload when changing service configuration